### PR TITLE
Fix -127C readings for water temperature sensor

### DIFF
--- a/ardesp/waterelf32/waterelf32.ino
+++ b/ardesp/waterelf32/waterelf32.ino
@@ -967,8 +967,15 @@ void formatMonitorEntry(monitor_t *m, String* buf, bool JSON) {
   }
 }
 void getTemperature(float* waterCelsius) {
-  tempSensor.requestTemperatures(); // send command to get temperatures
+  portDISABLE_INTERRUPTS();
+  // send command to get temperatures
+  tempSensor.requestTemperaturesByAddress(tempAddr);
+  portENABLE_INTERRUPTS();
+  //these interrupt disables are separate as we don't care about interrupts
+  //between readings
+  portDISABLE_INTERRUPTS();
   (*waterCelsius) = tempSensor.getTempC(tempAddr);
+  portENABLE_INTERRUPTS();
   dbg(monitorDBG, "Water temp: ");
   dbg(monitorDBG, *waterCelsius);
   dln(monitorDBG, " C, ");

--- a/ardesp/waterelf32/waterelf32.ino
+++ b/ardesp/waterelf32/waterelf32.ino
@@ -967,15 +967,15 @@ void formatMonitorEntry(monitor_t *m, String* buf, bool JSON) {
   }
 }
 void getTemperature(float* waterCelsius) {
-  portDISABLE_INTERRUPTS();
+  taskDISABLE_INTERRUPTS();
   // send command to get temperatures
   tempSensor.requestTemperaturesByAddress(tempAddr);
-  portENABLE_INTERRUPTS();
+  taskENABLE_INTERRUPTS();
   //these interrupt disables are separate as we don't care about interrupts
   //between readings
-  portDISABLE_INTERRUPTS();
+  taskDISABLE_INTERRUPTS();
   (*waterCelsius) = tempSensor.getTempC(tempAddr);
-  portENABLE_INTERRUPTS();
+  taskENABLE_INTERRUPTS();
   dbg(monitorDBG, "Water temp: ");
   dbg(monitorDBG, *waterCelsius);
   dln(monitorDBG, " C, ");

--- a/ardesp/waterelf32/waterelf32.ino
+++ b/ardesp/waterelf32/waterelf32.ino
@@ -967,6 +967,9 @@ void formatMonitorEntry(monitor_t *m, String* buf, bool JSON) {
   }
 }
 void getTemperature(float* waterCelsius) {
+  //HACK: we need to manually disable interrupts here because the arduino
+  //      functions `interrupts` and `noInterrupts` are no-ops in esp32-arduino
+  //      see: https://github.com/espressif/arduino-esp32/issues/832
   taskDISABLE_INTERRUPTS();
   // send command to get temperatures
   tempSensor.requestTemperaturesByAddress(tempAddr);


### PR DESCRIPTION
This should fix the water temp sensor giving spurious readings of -127C (indicating disconnected). Note this is probably the same root cause as in [my comment on the DHT issue](https://github.com/hamishcunningham/fishy-wifi/issues/15#issuecomment-348940686), but this type of in-tree fix, while easier to maintain doesn't seem to work for the DHT (the timing of setting interrupts seems to be more crucial for the DHT sensor for some reason).

For review: Should I add comments mentioning why this workaround is here?